### PR TITLE
feat: category CRUD backend

### DIFF
--- a/backend/controllers/categoryController.js
+++ b/backend/controllers/categoryController.js
@@ -1,0 +1,49 @@
+const categoryService = require('../services/categoryService');
+
+exports.createCategory = async (req, res) => {
+    try {
+        const newCategory = await categoryService.createCategory(req.body);
+        res.json(newCategory);
+    } catch (err) {
+        res.status(500).json({error: err.message});
+    }
+}
+
+exports.viewCategories = async (req, res) => {
+    try {
+        const categories = await categoryService.viewCategories();
+        res.json(categories);
+    } catch (err) {
+        res.status(500).json({error: err.message});
+    }
+}
+
+exports.getCategoryById = async (req, res) => {
+    try {
+        const {id} = req.params;
+        const category = await categoryService.getCategoryById(id);
+        res.json(category);
+    } catch (err) {
+        res.status(500).json({error: err.message});
+    }
+}
+
+exports.updateCategory = async (req, res) => {
+    try {
+        const {id} = req.params;
+        const updated = await categoryService.updateCategory(req.body, id);
+        res.json(updated);
+    } catch (err) {
+        res.status(500).json({error: err.message});
+    }
+}
+
+exports.disableCategory = async (req, res) => {
+    try {
+        const {id} = req.params;
+        const disabled = await categoryService.disableCategory(id);
+        res.json(disabled);
+    } catch (err) {
+        res.status(500).json({error: err.message});
+    }
+}

--- a/backend/index.js
+++ b/backend/index.js
@@ -15,6 +15,6 @@ app.use(cors({
 }));
 app.use(express.json());
 app.use('/event', require("./routes/eventRoute"));
-
+app.use('/category', require("./routes/categoryRoute"));
 
 app.listen(port, () => console.log("Server running on port " + port));

--- a/backend/models/category.js
+++ b/backend/models/category.js
@@ -1,0 +1,8 @@
+class Category {
+    constructor({name, description = null}) {
+        this.name = name;
+        this.description = description;
+    }
+}
+
+module.exports = Category;

--- a/backend/models/categoryModel.js
+++ b/backend/models/categoryModel.js
@@ -1,0 +1,22 @@
+const db = require('../database');
+
+const getAll = () => db.any('SELECT * FROM category WHERE status = true');
+const getById = (id) => db.one('SELECT * FROM category WHERE id = $(id)', {id});
+const create = (category) => db.one(`
+    INSERT INTO category (name, description, status)
+    VALUES ($(name), $(description), true)
+    RETURNING *`, category);
+const update = (newCategory, id) => db.one(`
+    UPDATE category
+    SET name=$(name),
+        description=$(description)
+    WHERE id = $(id)
+    RETURNING *`, {...newCategory, id});
+const disable = (id) => db.one(`
+    UPDATE category
+    SET status = false
+    WHERE id = $(id)
+    RETURNING *`, {id});
+
+module.exports = {getAll, getById, create, update, disable};
+

--- a/backend/routes/categoryRoute.js
+++ b/backend/routes/categoryRoute.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const categoryController = require('../controllers/categoryController');
+
+router.post('/create', categoryController.createCategory);
+router.get('/', categoryController.viewCategories);
+router.get('/:id', categoryController.getCategoryById);
+router.put('/update/:id', categoryController.updateCategory);
+router.patch('/disable/:id', categoryController.disableCategory);
+
+module.exports = router;

--- a/backend/services/categoryService.js
+++ b/backend/services/categoryService.js
@@ -1,0 +1,23 @@
+const Category = require('../models/category');
+const CategoryModel = require('../models/categoryModel');
+
+exports.createCategory = (data) => {
+    const newCategory = new Category(data);
+    return CategoryModel.create(newCategory);
+}
+
+exports.viewCategories = () => {
+    return CategoryModel.getAll();
+}
+
+exports.getCategoryById = (id) => {
+    return CategoryModel.getById(id);
+}
+
+exports.updateCategory = (data, id) => {
+    return CategoryModel.update(data, id);
+}
+
+exports.disableCategory = (id) => {
+    return CategoryModel.disable(id);
+}


### PR DESCRIPTION
This PR adds the full CRUD logic for managing categories in the backend. It includes endpoints, controllers, and operations needed to create, read, update, and disable categories.

Changes Included

Added CRUD endpoints for categories.

Implemented controller and service logic.
