### PR TITLE
feat: limit 10 events by page

### DIFF
--- a/backend/controllers/eventController.js
+++ b/backend/controllers/eventController.js
@@ -6,8 +6,16 @@ exports.createEvent = async (req, res) => {
 }
 
 exports.viewEvents = async (req, res) => {
-    const events = await eventService.viewEvents();
-    res.json(events);
+    try {
+        const page = parseInt(req.query.page) || 1;
+        const events = await eventService.viewEvents(page);
+        res.json({
+            page: page,
+            data: events
+        });
+    } catch (err) {
+        res.status(500).json({ error: err.message });
+    }
 }
 
 exports.updateEvent = async (req, res) => {

--- a/backend/models/eventModel.js
+++ b/backend/models/eventModel.js
@@ -1,7 +1,7 @@
 const db = require('../database');
 
-// const getAll = () => db.any('SELECT * FROM event LIMIT 1');
-const getAll = () => db.any('SELECT * FROM event WHERE status = true');
+const getAll = (limit, offset) =>
+    db.any('SELECT * FROM event WHERE status = true ORDER BY id LIMIT $1 OFFSET $2', [limit, offset]);
 const create = (event) => db.one(`INSERT INTO event (name, date, description, image, category_id, price, status)
                                   VALUES ($(name), $(date), $(description), $(image), $(category_id),
                                           $(price), true)

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.6",
+        "dotenv": "^17.3.1",
         "express": "^5.2.1",
         "pg-promise": "^12.6.1"
       }
@@ -166,6 +167,17 @@
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "cors": "^2.8.6",
+    "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "pg-promise": "^12.6.1"
   }

--- a/backend/services/eventService.js
+++ b/backend/services/eventService.js
@@ -12,10 +12,10 @@ exports.createEvent = (event) => {
     return EventModel.create(newEvent)
 }
 
-exports.viewEvents = async () => {
-    console.log('view events');
-    console.log(await EventModel.getAll());
-    return EventModel.getAll()
+exports.viewEvents = async (page) => {
+    const limit = 10;
+    const offset = (page - 1) * limit;
+    return EventModel.getAll(limit, offset);
 }
 
 exports.updateEvent = (newEvent,id) => {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,7 +1,7 @@
 const container = document.getElementById("events-container");
 const API_URL = "http://localhost:3250/event";
+let pageNumber = 1;
 
-// ← estas dos funciones deben estar AQUÍ, fuera de todo
 async function loadCategoriesSelect(selectId) {
     try {
         const res = await fetch("http://localhost:3250/category");
@@ -26,11 +26,12 @@ function setMinDate(inputId) {
     document.getElementById(inputId).min = min;
 }
 
-async function loadEvents() {
+async function loadEvents(page = 1) {
     try {
-        const res = await fetch(API_URL);
-        const events = await res.json();
-        renderEvents(events);
+        const res = await fetch(`${API_URL}?page=${page}`);
+        const json = await res.json();
+        // La API devuelve { page, data: [...] }
+        renderEvents(json.data);
     } catch (err) {
         container.innerHTML = "<p>Error loading events</p>";
         console.error(err);
@@ -39,6 +40,10 @@ async function loadEvents() {
 
 function renderEvents(events) {
     container.innerHTML = "";
+    if (!events || events.length === 0) {
+        container.innerHTML = "<p>No hay eventos disponibles.</p>";
+        return;
+    }
     events.forEach(event => {
         const card = document.createElement("div");
         card.className = "card";
@@ -60,6 +65,11 @@ function openAddModal() {
     loadCategoriesSelect("a-category");
     setMinDate("a-date");
     document.getElementById("add-modal").classList.add("active");
+}
+
+function nextPage(){
+    pageNumber++;
+    loadEvents(pageNumber);
 }
 
 function closeAddModal() {
@@ -101,4 +111,4 @@ async function handleCreateEvent() {
     }
 }
 
-loadEvents();
+loadEvents(pageNumber);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,6 +12,7 @@
     <h1>Eventos</h1>
     <a href="categories.html" class="btn-nav">Categorías</a>
     <button class="btn-add" onclick="openAddModal()">+ Añadir Evento</button>
+    <button class="btn-next-page" onclick="nextPage()">Siguinete pagina</button>
 </header>
 
 <main>


### PR DESCRIPTION
## Descripción  
En este PR se incorpora la funcionalidad de paginación para la entidad Evento, limitando la consulta a 10 registros por página.  

## Cambios realizados  

### Paginación de Eventos  
- Se limita la consulta a 10 eventos por petición a la base de datos.  
- Se implementa el uso de parámetros de paginación (limit y offset).  
- Se añade en la pantalla principal un botón **"Siguiente página"**, el cual incrementa la consulta en bloques de 10 eventos.

### Integración por capas  
Se realizaron modificaciones en las siguientes capas para soportar la paginación:

- `models/`  
- `controllers/`  
- `services/`  
- `routes/`  

En el controlador se ajustó la lógica para recibir y procesar los parámetros de paginación.  
En los servicios se modificó la consulta para aplicar el límite de 10 registros.  
En el modelo se adaptó la consulta a base de datos para soportar limit y offset.  
En las rutas se actualizaron los endpoints para permitir el envío de los parámetros correspondientes.

## Impacto  
- Mejora el rendimiento al reducir la cantidad de datos cargados por petición.  
- Establece una base escalable para el manejo de grandes volúmenes de eventos.