### PR TITLE
Fix: Load categories in event edit form to match create form behavior

### DIFF
--- a/frontend/src/components/EventForm.jsx
+++ b/frontend/src/components/EventForm.jsx
@@ -1,0 +1,101 @@
+// src/components/EventForm.jsx
+import { useRef, useEffect } from 'react'
+import FormField from './FormField'
+
+function setMinDate(ref) {
+  if (!ref.current) return
+  const now = new Date()
+  const pad = (n) => String(n).padStart(2, '0')
+  ref.current.min = `${now.getFullYear()}-${pad(now.getMonth()+1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(now.getMinutes())}`
+}
+
+export default function EventForm({ form, setForm, categories = [], onSubmit, onCancel, saving, submitLabel = 'Guardar' }) {
+  const dateRef = useRef(null)
+
+  useEffect(() => {
+    setTimeout(() => setMinDate(dateRef), 50)
+  }, [])
+
+  return (
+    <form onSubmit={onSubmit}>
+      <FormField label="Nombre *">
+        <input
+          className="field-input"
+          value={form.name}
+          onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+          placeholder="Nombre del evento"
+          required
+        />
+      </FormField>
+      <FormField label="Fecha">
+        <input
+          ref={dateRef}
+          className="field-input"
+          type="datetime-local"
+          value={form.date}
+          onChange={e => setForm(f => ({ ...f, date: e.target.value }))}
+        />
+      </FormField>
+      <FormField label="Descripción">
+        <textarea
+          className="field-input"
+          rows={3}
+          value={form.description}
+          onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
+          placeholder="Descripción del evento"
+        />
+      </FormField>
+      <FormField label="Imagen (URL)">
+        <input
+          className="field-input"
+          value={form.image}
+          onChange={e => setForm(f => ({ ...f, image: e.target.value }))}
+          placeholder="https://..."
+        />
+      </FormField>
+
+      {/* Solo se muestra si se pasan categorías (crear), se omite en editar si no aplica */}
+      {categories.length > 0 && (
+        <FormField label="Categoría">
+          <select
+            className="field-input"
+            value={form.category_id || ''}
+            onChange={e => setForm(f => ({ ...f, category_id: e.target.value }))}
+          >
+            <option value="">Sin categoría</option>
+            {categories.map(c => (
+              <option key={c.id} value={c.id}>{c.name}</option>
+            ))}
+          </select>
+        </FormField>
+      )}
+
+      <FormField label="Precio">
+        <input
+          className="field-input"
+          type="number"
+          value={form.price}
+          onChange={e => setForm(f => ({ ...f, price: e.target.value }))}
+          placeholder="0"
+        />
+      </FormField>
+
+      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.75rem', marginTop: '1.25rem' }}>
+        <button
+          type="button"
+          onClick={onCancel}
+          style={{ padding: '0.55rem 1.2rem', border: '1.5px solid var(--border)', borderRadius: '10px', background: 'white', fontWeight: 600, fontSize: '0.875rem' }}
+        >
+          Cancelar
+        </button>
+        <button
+          type="submit"
+          disabled={saving}
+          style={{ padding: '0.55rem 1.4rem', background: 'var(--ink)', color: 'white', border: 'none', borderRadius: '10px', fontWeight: 600, fontSize: '0.875rem', opacity: saving ? 0.5 : 1, cursor: saving ? 'not-allowed' : 'pointer' }}
+        >
+          {saving ? 'Guardando...' : submitLabel}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/pages/DetailPage.jsx
+++ b/frontend/src/pages/DetailPage.jsx
@@ -1,27 +1,32 @@
 import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { getEvent, updateEvent, disableEvent, registerInterest } from '../api/api'
+import { getEvent, updateEvent, disableEvent, registerInterest, getCategories } from '../api/api'
 import Modal from '../components/Modal'
-import FormField from '../components/FormField'
+import EventForm from '../components/EventForm'
 import Spinner from '../components/Spinner'
 import styles from './DetailPage.module.css'
 
 export default function DetailPage() {
   const { id } = useParams()
   const navigate = useNavigate()
-  const [event, setEvent]       = useState(null)
-  const [loading, setLoading]   = useState(true)
+  const [event, setEvent]         = useState(null)
+  const [loading, setLoading]     = useState(true)
   const [modalOpen, setModalOpen] = useState(false)
-  const [saving, setSaving]     = useState(false)
+  const [saving, setSaving]       = useState(false)
   const [interested, setInterested] = useState(false)
+  const [categories, setCategories] = useState([])
   const [form, setForm] = useState({
-    name: '', date: '', description: '', image: '', price: ''
+    name: '', date: '', description: '', image: '', price: '', category_id: ''
   })
 
   async function load() {
     setLoading(true)
     try {
-      const data = await getEvent(id)
+      const [data, cats] = await Promise.all([
+        getEvent(id),
+        getCategories(),
+      ])
+      setCategories(cats)
       setEvent(data)
       setForm({
         name:        data.name || '',
@@ -29,6 +34,7 @@ export default function DetailPage() {
         description: data.description || '',
         image:       data.image || '',
         price:       data.price || '',
+        category_id: data.category_id || '',
       })
     } catch {
       setEvent(null)
@@ -48,7 +54,7 @@ export default function DetailPage() {
         date:        form.date || null,
         description: form.description || null,
         image:       form.image || null,
-        category_id: null,
+        category_id: form.category_id || null,
         price:       form.price || null,
       })
       setEvent(updated)
@@ -141,55 +147,15 @@ export default function DetailPage() {
       </div>
 
       <Modal open={modalOpen} onClose={() => setModalOpen(false)} title="Editar Evento">
-        <form onSubmit={handleSave}>
-          <FormField label="Nombre">
-            <input
-              className="field-input"
-              value={form.name}
-              onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
-            />
-          </FormField>
-          <FormField label="Fecha">
-            <input
-              className="field-input"
-              type="datetime-local"
-              value={form.date}
-              onChange={e => setForm(f => ({ ...f, date: e.target.value }))}
-            />
-          </FormField>
-          <FormField label="Descripción">
-            <textarea
-              className="field-input"
-              rows={3}
-              value={form.description}
-              onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
-            />
-          </FormField>
-          <FormField label="Imagen (URL)">
-            <input
-              className="field-input"
-              value={form.image}
-              onChange={e => setForm(f => ({ ...f, image: e.target.value }))}
-              placeholder="https://..."
-            />
-          </FormField>
-          <FormField label="Precio">
-            <input
-              className="field-input"
-              type="number"
-              value={form.price}
-              onChange={e => setForm(f => ({ ...f, price: e.target.value }))}
-            />
-          </FormField>
-          <div className={styles.modalActions}>
-            <button type="button" className={styles.btnCancelModal} onClick={() => setModalOpen(false)}>
-              Cancelar
-            </button>
-            <button type="submit" className={styles.btnSaveModal} disabled={saving}>
-              {saving ? 'Guardando...' : 'Guardar'}
-            </button>
-          </div>
-        </form>
+        <EventForm
+          form={form}
+          setForm={setForm}
+          categories={categories}
+          onSubmit={handleSave}
+          onCancel={() => setModalOpen(false)}
+          saving={saving}
+          submitLabel="Guardar"
+        />
       </Modal>
     </div>
   )

--- a/frontend/src/pages/EventsPage.jsx
+++ b/frontend/src/pages/EventsPage.jsx
@@ -1,28 +1,19 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { getEvents, createEvent, getCategories } from '../api/api'
 import Modal from '../components/Modal'
-import FormField from '../components/FormField'
+import EventForm from '../components/EventForm'  // ← nuevo import
 import Spinner from '../components/Spinner'
 import styles from './EventsPage.module.css'
 
-function setMinDate(ref) {
-  if (!ref.current) return
-  const now = new Date()
-  const pad = (n) => String(n).padStart(2, '0')
-  ref.current.min = `${now.getFullYear()}-${pad(now.getMonth()+1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(now.getMinutes())}`
-}
-
 export default function EventsPage() {
   const navigate = useNavigate()
-  const [events, setEvents]       = useState([])
-  const [loading, setLoading]     = useState(true)
-  const [page, setPage]           = useState(1)
-  const [modalOpen, setModalOpen] = useState(false)
+  const [events, setEvents]         = useState([])
+  const [loading, setLoading]       = useState(true)
+  const [page, setPage]             = useState(1)
+  const [modalOpen, setModalOpen]   = useState(false)
   const [categories, setCategories] = useState([])
-  const [saving, setSaving]       = useState(false)
-
-  const dateRef = useRef(null)
+  const [saving, setSaving]         = useState(false)
 
   const [form, setForm] = useState({
     name: '', date: '', description: '', image: '', category_id: '', price: ''
@@ -44,7 +35,6 @@ export default function EventsPage() {
     getCategories().then(setCategories).catch(() => {})
     setForm({ name: '', date: '', description: '', image: '', category_id: '', price: '' })
     setModalOpen(true)
-    setTimeout(() => setMinDate(dateRef), 50)
   }
 
   async function handleCreate(e) {
@@ -131,73 +121,17 @@ export default function EventsPage() {
         </div>
       )}
 
+      {/* ↓ Todo el <form> reemplazado por EventForm */}
       <Modal open={modalOpen} onClose={() => setModalOpen(false)} title="Nuevo Evento">
-        <form onSubmit={handleCreate}>
-          <FormField label="Nombre *">
-            <input
-              className="field-input"
-              value={form.name}
-              onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
-              placeholder="Nombre del evento"
-              required
-            />
-          </FormField>
-          <FormField label="Fecha">
-            <input
-              ref={dateRef}
-              className="field-input"
-              type="datetime-local"
-              value={form.date}
-              onChange={e => setForm(f => ({ ...f, date: e.target.value }))}
-            />
-          </FormField>
-          <FormField label="Descripción">
-            <textarea
-              className="field-input"
-              rows={3}
-              value={form.description}
-              onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
-              placeholder="Descripción del evento"
-            />
-          </FormField>
-          <FormField label="Imagen (URL)">
-            <input
-              className="field-input"
-              value={form.image}
-              onChange={e => setForm(f => ({ ...f, image: e.target.value }))}
-              placeholder="https://..."
-            />
-          </FormField>
-          <FormField label="Categoría">
-            <select
-              className="field-input"
-              value={form.category_id}
-              onChange={e => setForm(f => ({ ...f, category_id: e.target.value }))}
-            >
-              <option value="">Sin categoría</option>
-              {categories.map(c => (
-                <option key={c.id} value={c.id}>{c.name}</option>
-              ))}
-            </select>
-          </FormField>
-          <FormField label="Precio">
-            <input
-              className="field-input"
-              type="number"
-              value={form.price}
-              onChange={e => setForm(f => ({ ...f, price: e.target.value }))}
-              placeholder="0"
-            />
-          </FormField>
-          <div className={styles.modalActions}>
-            <button type="button" className={styles.btnCancel} onClick={() => setModalOpen(false)}>
-              Cancelar
-            </button>
-            <button type="submit" className={styles.btnSave} disabled={saving}>
-              {saving ? 'Creando...' : 'Crear'}
-            </button>
-          </div>
-        </form>
+        <EventForm
+          form={form}
+          setForm={setForm}
+          categories={categories}
+          onSubmit={handleCreate}
+          onCancel={() => setModalOpen(false)}
+          saving={saving}
+          submitLabel="Crear"
+        />
       </Modal>
     </div>
   )


### PR DESCRIPTION
This update enhances the event edit form by loading the list of categories directly from the database, matching the behavior of the create form.

### Changes included:
- Fetched category list when opening the edit form.
- Populated the category dropdown with the available categories.
- Ensured consistency between the create and edit forms.
- Improved user experience by preventing mismatched or outdated category values.

