### PR TITLE
feat: Implemented middleware on endpoints

### DIFF
--- a/backend/middlewares/authMiddleware.js
+++ b/backend/middlewares/authMiddleware.js
@@ -18,9 +18,14 @@ export function authenticateToken(req, res, next) {
 }
 
 export function adminAuthorized(req, res, next) {
-    console.log(req.user);
-    console.log("El rol es: "+req.user.role);
     if (req.user.role !== 'admin') {
+        return res.status(403).json({message: 'Acceso denegado'});
+    }
+    next();
+}
+
+export function updateUserAuthorized(req, res, next) {
+    if (Number(req.params.id) !== Number(req.user.id) && req.user.role !== 'Admin') {
         return res.status(403).json({message: 'Acceso denegado'});
     }
     next();

--- a/backend/routes/categoryRoute.js
+++ b/backend/routes/categoryRoute.js
@@ -1,11 +1,12 @@
 const express = require('express');
 const router = express.Router();
 const categoryController = require('../controllers/categoryController');
+const authentication = require("../middlewares/authMiddleware");
 
-router.post('/create', categoryController.createCategory);
+router.post('/create', authentication.authenticateToken, authentication.adminAuthorized, categoryController.createCategory);
 router.get('/', categoryController.viewCategories);
 router.get('/:id', categoryController.getCategoryById);
-router.put('/update/:id', categoryController.updateCategory);
-router.patch('/disable/:id', categoryController.disableCategory);
+router.put('/update/:id', authentication.authenticateToken, authentication.adminAuthorized, categoryController.updateCategory);
+router.patch('/disable/:id', authentication.authenticateToken, authentication.adminAuthorized, categoryController.disableCategory);
 
 module.exports = router;

--- a/backend/routes/eventRoute.js
+++ b/backend/routes/eventRoute.js
@@ -2,18 +2,19 @@ const express = require('express');
 const router = express.Router();
 const eventController = require('../controllers/eventController');
 const {getById} = require("../models/eventModel");
+const authentication = require("../middlewares/authMiddleware");
 
-router.post('/create', eventController.createEvent);
+router.post('/create', authentication.authenticateToken, authentication.adminAuthorized, eventController.createEvent);
 router.get('/', eventController.viewEvents);
-router.put('/update/:id',eventController.updateEvent);
-router.patch('/disable/:id',eventController.disableEvent);
+router.put('/update/:id', authentication.authenticateToken, authentication.adminAuthorized, eventController.updateEvent);
+router.patch('/disable/:id', authentication.authenticateToken, authentication.adminAuthorized, eventController.disableEvent);
 router.patch('/interested/:id', eventController.interestEvent);
-router.get("/getAllInterested", eventController.getAllInterest);
+router.get("/getAllInterested", authentication.authenticateToken, authentication.adminAuthorized, eventController.getAllInterest);
 router.get('/:id', eventController.getEventById);
 
-router.post('/:id/favorite',           eventController.addFavorite);
-router.delete('/:id/favorite',         eventController.removeFavorite);
-router.get('/favorites/user/:userId',  eventController.getFavoritesByUser);
-router.get('/favorites/report',        eventController.getFavoritesReport);
+router.post('/:id/favorite', eventController.addFavorite);
+router.delete('/:id/favorite', eventController.removeFavorite);
+router.get('/favorites/user/:userId', eventController.getFavoritesByUser);
+router.get('/favorites/report', authentication.authenticateToken, authentication.adminAuthorized, eventController.getFavoritesReport);
 
 module.exports = router;

--- a/backend/routes/userRoute.js
+++ b/backend/routes/userRoute.js
@@ -4,8 +4,8 @@ const userController = require('../controllers/userController');
 const authentication = require('../middlewares/authMiddleware');
 
 router.post('/create', userController.createUser);
-router.get('/', userController.viewUsers);
-router.put('/update/:id', userController.updateUser);
+router.get('/', authentication.authenticateToken, authentication.adminAuthorized, userController.viewUsers);
+router.put('/update/:id', authentication.authenticateToken, authentication.updateUserAuthorized, userController.updateUser);
 router.get('/:id', authentication.authenticateToken, authentication.adminAuthorized, userController.getUserById);
 
 


### PR DESCRIPTION
## Descripción  
En este PR se amplía la protección de endpoints para que solo puedan ser accedidos por usuarios con rol de **administrador**.  

## Cambios realizados  

### Backend  

- Se aplican los middlewares:
  - `authenticateToken`
  - `adminAuthorized`

  a los endpoints que requieren permisos de administrador.

- Se crea un nuevo middleware:
  - `updateUserAuthorized`: utilizado específicamente en el endpoint de actualización de usuario.

### Endpoints protegidos  

#### Category
- `updateCategory`
- `disableCategory`
- `createCategory`

#### Event
- `getAllInterest`
- `updateEvent`
- `disableEvent`
- `createEvent`
- `getFavoritesReport`

#### User
- `viewUsers`
- `updateUser` (usa `updateUserAuthorized`)

### Frontend  
- No se realizaron cambios en el frontend.