### PR TITLE
Fix persistence of "Interested" state for events in frontend

### DIFF
--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -95,3 +95,9 @@ export const disableCategory = (id) =>
 
 export const registerClick = (id) =>
   fetch(`${API_BASE}/event/interested/${id}`, { method: 'PATCH' })
+
+
+export const getUserFavorites = (userId) =>
+  fetch(`${API_BASE}/event/favorites/user/${userId}`, {
+    headers: getHeaders(),
+  }).then(r => r.json())

--- a/frontend/src/pages/DetailPage.jsx
+++ b/frontend/src/pages/DetailPage.jsx
@@ -1,11 +1,20 @@
 import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { getEvent, updateEvent, disableEvent, registerInterest, unregisterInterest, getCategories } from '../api/api'
+import { getEvent, updateEvent, disableEvent, registerInterest, unregisterInterest, getCategories, getUserFavorites } from '../api/api'
 import Modal from '../components/Modal'
 import EventForm from '../components/EventForm'
 import Spinner from '../components/Spinner'
 import styles from './DetailPage.module.css'
 import {useAuth} from "../context/AuthContext.jsx";
+
+
+function getUserIdFromToken() {
+  const token = localStorage.getItem('token')
+  if (!token) return null
+  try {
+    return JSON.parse(atob(token.split('.')[1]))?.id || null
+  } catch { return null }
+}
 
 export default function DetailPage() {
   const { id } = useParams()
@@ -24,12 +33,15 @@ export default function DetailPage() {
   async function load() {
     setLoading(true)
     try {
-      const [data, cats] = await Promise.all([
+      const userId = getUserIdFromToken()
+      const [data, cats,favorites] = await Promise.all([
         getEvent(id),
         getCategories(),
+        userId ? getUserFavorites(userId) : Promise.resolve([]),
       ])
       setCategories(cats)
       setEvent(data)
+      setInterested(favorites.some(f => f.id === Number(id)))
       setForm({
         name:        data.name || '',
         date:        data.date ? data.date.slice(0, 16) : '',


### PR DESCRIPTION
This update fixes the behavior of the **"Interested"** button in the frontend to correctly reflect a user's previously selected favorite events.

### Changes:
- Updated the frontend logic to load the user's favorite events when a session starts.
- Ensured events previously marked as **"Interested"** appear with the button already selected.
- Prevented users from needing to mark the same events again after logging back into the application.

This improvement enhances user experience by maintaining the correct favorite state across sessions.