### PR TITLE
Add admin-only likes report with limit control and extend feature to click report

### DIFF
--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -101,3 +101,9 @@ export const getUserFavorites = (userId) =>
   fetch(`${API_BASE}/event/favorites/user/${userId}`, {
     headers: getHeaders(),
   }).then(r => r.json())
+
+
+  export const getFavoritesReport = () =>
+  fetch(`${API_BASE}/event/favorites/report`, {
+    headers: getHeaders(),
+  }).then(r => r.json())

--- a/frontend/src/pages/ReportPage.jsx
+++ b/frontend/src/pages/ReportPage.jsx
@@ -1,21 +1,27 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
-import { getEvents, getAllInterested } from '../api/api'
+import { getAllInterested, getFavoritesReport } from '../api/api'
 import Spinner from '../components/Spinner'
 import styles from './ReportPage.module.css'
 
+const TOP = 10
+
 export default function ReportPage() {
-  const [rows, setRows]     = useState([])
-  const [loading, setLoading] = useState(true)
+  const [clickRows, setClickRows]         = useState([])
+  const [favoriteRows, setFavoriteRows]   = useState([])
+  const [loading, setLoading]             = useState(true)
+  const [showAllClicks, setShowAllClicks] = useState(false)
+  const [showAllFavs, setShowAllFavs]     = useState(false)
 
   useEffect(() => {
     async function load() {
       try {
-        const [eventsJson, interests] = await Promise.all([
-          getEvents(1),
+        const [interests, favorites] = await Promise.all([
           getAllInterested(),
+          getFavoritesReport(),
         ])
 
+        // Reporte clicks: agrupar por event_id
         const countMap = {}
         interests.forEach(i => {
           if (i.type === 'click') {
@@ -23,13 +29,19 @@ export default function ReportPage() {
           }
         })
 
-        const sorted = [...(eventsJson.data || [])].sort(
-          (a, b) => (countMap[b.id] || 0) - (countMap[a.id] || 0)
-        )
+        // Usar favorites como fuente de nombres (tiene todos los eventos)
+        const clicksSorted = favorites
+          .map(ev => ({ ...ev, count: countMap[ev.id] || 0 }))
+          .sort((a, b) => b.count - a.count)
 
-        setRows(sorted.map(ev => ({ ...ev, count: countMap[ev.id] || 0 })))
+        setClickRows(clicksSorted)
+
+        // Reporte favoritos
+        setFavoriteRows(favorites.map(ev => ({ ...ev, count: Number(ev.total_favorites) })))
+
       } catch {
-        setRows([])
+        setClickRows([])
+        setFavoriteRows([])
       } finally {
         setLoading(false)
       }
@@ -37,29 +49,24 @@ export default function ReportPage() {
     load()
   }, [])
 
-  const maxCount = rows.length > 0 ? Math.max(...rows.map(r => r.count), 1) : 1
+  const maxClicks    = clickRows.length    > 0 ? Math.max(...clickRows.map(r => r.count), 1)    : 1
+  const maxFavorites = favoriteRows.length > 0 ? Math.max(...favoriteRows.map(r => r.count), 1) : 1
 
-  return (
-    <div className={styles.page}>
-      <h1 className={styles.heading}>Reporte de Intereses</h1>
-      <p className={styles.sub}>Eventos ordenados por cantidad de "Me interesa"</p>
-
-      {loading ? (
-        <Spinner />
-      ) : rows.length === 0 ? (
-        <p className={styles.empty}>No hay datos para mostrar.</p>
-      ) : (
+  const RankingTable = ({ rows, maxCount, showAll, onToggle }) => {
+    const visible = showAll ? rows : rows.slice(0, TOP)
+    return (
+      <>
         <div className={styles.tableWrap}>
           <table className={styles.table}>
             <thead>
               <tr>
                 <th>#</th>
                 <th>Evento</th>
-                <th>Me interesa</th>
+                <th>Total</th>
               </tr>
             </thead>
             <tbody>
-              {rows.map((row, i) => (
+              {visible.map((row, i) => (
                 <tr key={row.id} className={styles.row} style={{ animationDelay: `${i * 0.04}s` }}>
                   <td className={styles.rank}>#{i + 1}</td>
                   <td className={styles.name}>
@@ -79,6 +86,39 @@ export default function ReportPage() {
             </tbody>
           </table>
         </div>
+        {rows.length > TOP && (
+          <button className={styles.btnToggle} onClick={onToggle}>
+            {showAll ? `▲ Mostrar solo Top ${TOP}` : `▼ Ver todos (${rows.length})`}
+          </button>
+        )}
+      </>
+    )
+  }
+
+  return (
+    <div className={styles.page}>
+      {loading ? (
+        <Spinner />
+      ) : (
+        <>
+          <section>
+            <h1 className={styles.heading}>Reporte de Clicks</h1>
+            <p className={styles.sub}>Eventos ordenados por cantidad de clicks recibidos</p>
+            {clickRows.length === 0
+              ? <p className={styles.empty}>No hay datos para mostrar.</p>
+              : <RankingTable rows={clickRows} maxCount={maxClicks} showAll={showAllClicks} onToggle={() => setShowAllClicks(v => !v)} />
+            }
+          </section>
+
+          <section style={{ marginTop: '3rem' }}>
+            <h1 className={styles.heading}>Reporte de Favoritos</h1>
+            <p className={styles.sub}>Eventos ordenados por cantidad de "Me interesa"</p>
+            {favoriteRows.length === 0
+              ? <p className={styles.empty}>No hay datos para mostrar.</p>
+              : <RankingTable rows={favoriteRows} maxCount={maxFavorites} showAll={showAllFavs} onToggle={() => setShowAllFavs(v => !v)} />
+            }
+          </section>
+        </>
       )}
     </div>
   )

--- a/frontend/src/pages/ReportPage.module.css
+++ b/frontend/src/pages/ReportPage.module.css
@@ -115,3 +115,19 @@
   .heading { font-size: 1.6rem; }
   .table th, .table td { padding: 12px 14px; }
 }
+
+.btnToggle {
+  margin-top: 1rem;
+  padding: 0.5rem 1.25rem;
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  background: white;
+  font-weight: 600;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.btnToggle:hover {
+  background: var(--ink);
+  color: white;
+}


### PR DESCRIPTION
This update introduces the "Likes" report, available exclusively for administrators, and enhances both the likes and click reporting features with improved display controls.

### Key features:
- Implemented the **Likes Report** accessible only to admin users.
- Added a toggle button to switch between:
  - a limited view (top 10 ranked items)
  - the full report
- Applied the same limit-control mechanism to the **Click Report**.
- Improved consistency and usability across both reporting views.
- Enhanced administrator experience by providing clearer insights and better navigation between report modes.

These changes streamline reporting functionality and ensure administrators can easily access both summarized and full datasets.