### PR TITLE
fix: seed.sql table names and interaction references

### DIFF
--- a/backend/database/seed.sql
+++ b/backend/database/seed.sql
@@ -1,11 +1,11 @@
-INSERT INTO category (name, description, status) VALUES
+INSERT INTO categories (name, description, status) VALUES
 ('Música',      'Conciertos y festivales',     true),
 ('Deportes',    'Eventos deportivos',           true),
 ('Teatro',      'Obras y espectáculos',         true),
 ('Circo',       'Espectáculos circenses',       true),
 ('Conferencia', 'Charlas y conferencias',       true);
 
-INSERT INTO event (name, date, description, image, category_id, price, status)
+INSERT INTO events (name, date, description, image, category_id, price, status)
 SELECT
     'Evento #' || i,
     NOW() + (i || ' days')::interval,

--- a/backend/models/eventModel.js
+++ b/backend/models/eventModel.js
@@ -25,8 +25,8 @@ const disable = (id) => db.one(`UPDATE events
                                 RETURNING *`, {id});
 
 const getById = (id) => db.one('SELECT * FROM events WHERE id = $(id)', {id});
-const interest = (id) => db.none("INSERT INTO interaction (event_id, type) VALUES ($1, 'click')", [id])
-const getAllInterests = () => db.any('SELECT * FROM interaction');
+const interest = (id) => db.none("INSERT INTO interactions (event_id, type) VALUES ($1, 'click')", [id])
+const getAllInterests = () => db.any('SELECT * FROM interactions');
 
 const addFavorite    = (userId, eventId) => 
     db.none('INSERT INTO favorites (user_id, event_id) VALUES ($1, $2)', [userId, eventId]);


### PR DESCRIPTION
## Description  
This PR fixes issues in the database seeding process by correcting table naming inconsistencies and aligning them with the updated plural naming convention.

## Changes Made  

### Database  

- Fixed bugs in the `seed.sql` script.
- Updated table names from **singular to plural**:
  - `interaction` → `interactions`
  - `event` → `events`
- Ensured the seed data correctly targets the updated table names.

### Backend  

- Updated the **event model** to reflect the corrected table name (`interactions`).
- Resolved errors caused by mismatched table references between the backend and database.

### Notes  

- Important:
  - If the seed script was previously executed, it is recommended to **re-run the `seed.sql` script** after applying these changes.
  - This ensures data is inserted correctly into the updated table structure.