### PR TITLE
feat(user): add self-deactivation endpoint with soft delete logic

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -30,3 +30,13 @@ exports.getUserById = async (req, res) => {
         res.status(500).json({error: err.message});
     }
 }
+
+exports.deleteUser = async (req, res) => {
+    try {
+        const {id} = req.params;
+        const deleted = await userService.deleteUser(id);
+        res.json(deleted);
+    } catch (err) {
+        res.status(500).json({error: err.message});
+    }
+}

--- a/backend/database/init.sql
+++ b/backend/database/init.sql
@@ -12,7 +12,8 @@ CREATE TABLE IF NOT EXISTS users
     name     VARCHAR(150)        NOT NULL CHECK (TRIM(name) <> ''),
     email    VARCHAR(255) UNIQUE NOT NULL CHECK (TRIM(email) <> ''),
     password TEXT                NOT NULL,
-    role     VARCHAR(20)         NOT NULL DEFAULT 'Member' CHECK (role IN ('Admin', 'Member'))
+    role     VARCHAR(20)         NOT NULL DEFAULT 'Member' CHECK (role IN ('Admin', 'Member')),
+    status  BOOLEAN DEFAULT true
 );
 
 CREATE TABLE IF NOT EXISTS events

--- a/backend/middlewares/authMiddleware.js
+++ b/backend/middlewares/authMiddleware.js
@@ -31,3 +31,10 @@ export function updateUserAuthorized(req, res, next) {
     }
     next();
 }
+
+export function deleteUserAuthorized(req, res, next) {
+    if (Number(req.params.id) !== Number(req.user.id)) {
+        return res.status(403).json({message: 'Acceso denegado'});
+    }
+    next();
+}

--- a/backend/models/userModel.js
+++ b/backend/models/userModel.js
@@ -1,6 +1,6 @@
 const db = require('../database');
 
-const getAll = () => db.any('SELECT * FROM users');
+const getAll = () => db.any('SELECT * FROM users WHERE status = true');
 const create = (user) => db.one(`INSERT INTO users (name, email, password, role)
                                  VALUES ($(name), $(email), $(password), $(role)) RETURNING *`, user)
 const update = (newUser, id) => db.one(`UPDATE users
@@ -9,6 +9,7 @@ const update = (newUser, id) => db.one(`UPDATE users
                                             password=$(password),
                                             role=$(role)
                                         WHERE id = $(id) RETURNING *`, {...newUser, id});
-const getById = (id) => db.one('SELECT * FROM users WHERE id = $(id)', {id});
+const getById = (id) => db.one('SELECT * FROM users WHERE id = $(id) AND status = true', {id});
 const getByEmail = (email) => db.oneOrNone('SELECT * FROM users WHERE email = $(email)', {email});
-module.exports = {getAll, create, update, getById, getByEmail};
+const remove = (id) => db.oneOrNone('UPDATE users SET status = false WHERE id = $(id) RETURNING *', {id});
+module.exports = {getAll, create, update, getById, getByEmail, remove};

--- a/backend/routes/userRoute.js
+++ b/backend/routes/userRoute.js
@@ -7,6 +7,6 @@ router.post('/create', userController.createUser);
 router.get('/', authentication.authenticateToken, authentication.adminAuthorized, userController.viewUsers);
 router.put('/update/:id', authentication.authenticateToken, authentication.updateUserAuthorized, userController.updateUser);
 router.get('/:id', authentication.authenticateToken, authentication.adminAuthorized, userController.getUserById);
-
+router.delete('/delete/:id', authentication.authenticateToken, authentication.deleteUserAuthorized, userController.deleteUser);
 
 module.exports = router;

--- a/backend/services/userService.js
+++ b/backend/services/userService.js
@@ -29,3 +29,7 @@ exports.updateUser = (user, id) => {
 exports.getUserById = (id) => {
     return UserModel.getById(id);
 }
+
+exports.deleteUser = (id) => {
+    return UserModel.remove(id);s
+}


### PR DESCRIPTION
Adds an endpoint that allows users to deactivate their own accounts using a soft delete (status set to false). Authorization logic was updated to ensure that only the authenticated user can deactivate their own profile.