### PR TITLE
Enforce Admin Authentication on Ticket-Type Routes and Restrict User Access to Purchase Data

### DIFF
--- a/backend/controllers/ticketController.js
+++ b/backend/controllers/ticketController.js
@@ -22,9 +22,16 @@ exports.getById = async (req, res) => {
 exports.getTicketsByPurchase = async (req, res) => {
     try {
         const {purchaseId} = req.params;
-        const tickets = await ticketService.getTicketsByPurchase(purchaseId);
+        const userId = req.user.id;
+        const tickets = await ticketService.getTicketsByPurchase(purchaseId, userId);
         res.json(tickets);
     } catch (err) {
+        if (err.message === 'Acceso denegado') {
+            return res.status(403).json({error: err.message});
+        }
+        if (err.message === 'La compra no existe') {
+            return res.status(404).json({error: err.message});
+        }
         res.status(500).json({error: err.message});
     }
 }

--- a/backend/routes/eventTicketTypeRoute.js
+++ b/backend/routes/eventTicketTypeRoute.js
@@ -1,12 +1,14 @@
 const express = require('express');
 const router = express.Router();
 const eventTicketTypeController = require('../controllers/eventTicketTypeController');
+const authentication = require("../middlewares/authMiddleware");
 
-router.post('/create', eventTicketTypeController.createEventTicketType);
+router.post('/create', authentication.authenticateToken, authentication.adminAuthorized, eventTicketTypeController.createEventTicketType);
 router.get('/all/:eventId', eventTicketTypeController.getAllTicketTypes);
 router.get('/:eventId/:ticketId', eventTicketTypeController.getTicketTypeByIds);
-router.patch('/:eventId/:ticketTypeId/quantity', eventTicketTypeController.updateAvailableQuantity);
-router.put('/:eventId/:ticketTypeId', eventTicketTypeController.updateTicketType);
-router.delete('/:eventId/:ticketTypeId', eventTicketTypeController.deleteTicketType);
+router.patch('/:eventId/:ticketTypeId/quantity', authentication.authenticateToken, authentication.adminAuthorized, eventTicketTypeController.updateAvailableQuantity);
+router.put('/:eventId/:ticketTypeId',authentication.authenticateToken, authentication.adminAuthorized, eventTicketTypeController.updateTicketType);
+router.delete('/:eventId/:ticketTypeId',authentication.authenticateToken, authentication.adminAuthorized, eventTicketTypeController.deleteTicketType);
 
 module.exports = router;
+

--- a/backend/routes/ticketRoute.js
+++ b/backend/routes/ticketRoute.js
@@ -1,9 +1,10 @@
 const express = require('express');
 const router = express.Router();
 const ticketController = require('../controllers/ticketController');
+const authentication = require("../middlewares/authMiddleware");
 
-router.post('/create', ticketController.createTicket);
-router.get('/:id', ticketController.getById);
-router.get('/purchase/:purchaseId', ticketController.getTicketsByPurchase);
+router.post('/create',authentication.authenticateToken, authentication.adminAuthorized, ticketController.createTicket);
+router.get('/:id', authentication.authenticateToken, ticketController.getById);
+router.get('/purchase/:purchaseId', authentication.authenticateToken, ticketController.getTicketsByPurchase);
 
 module.exports = router;

--- a/backend/routes/ticketTypeRoute.js
+++ b/backend/routes/ticketTypeRoute.js
@@ -1,9 +1,9 @@
 const express = require('express');
 const router = express.Router();
 const ticketTypeController = require('../controllers/ticketTypeController');
+const authentication = require("../middlewares/authMiddleware");
 
-router.post('/create', ticketTypeController.createTicketType);
-// router.post('/create', authentication.authenticateToken,ticketTypeController.createTicketType);
+router.post('/create', authentication.authenticateToken, authentication.adminAuthorized, ticketTypeController.createTicketType);
 router.get('/all', ticketTypeController.getAllTicketTypes);
 router.get('/:id', ticketTypeController.getById)
 

--- a/backend/services/ticketService.js
+++ b/backend/services/ticketService.js
@@ -18,12 +18,13 @@ exports.getById = async (id) => {
     return ticket;
 }
 
-exports.getTicketsByPurchase = async (purchaseId) => {
-    const purchase = PurchaseModel.getById(purchaseId);
+exports.getTicketsByPurchase = async (purchaseId, userId) => {
+    const purchase = await PurchaseModel.getById(purchaseId);
     if (!purchase) {
         throw new Error('La compra no existe');
     }
-
-    const tickets = await TicketModel.getTicketsByPurchase(purchaseId);
-    return tickets;
+    if (purchase.user_id !== userId) {
+        throw new Error('Acceso denegado');
+    }
+    return TicketModel.getTicketsByPurchase(purchaseId);
 }


### PR DESCRIPTION
This pull request strengthens the system’s authorization layer in two key areas.
First, admin authentication was added to all routes involved in the creation and management of ticket types, ensuring that only authorized administrators can perform these actions and preventing standard users from modifying event ticket configurations.

Second, access control was improved to prevent users from viewing or modifying purchase information that does not belong to them. Additional checks were added to validate ownership before returning or updating any purchase-related data, ensuring proper data isolation and user privacy.

Key changes
Added admin-only access to all ticket-type creation and management endpoints.
Implemented authorization checks to block non-admin users from accessing those routes.
Added ownership validation so users can only view or modify their own purchase data.
Updated related controllers and middleware to centralize and standardize authorization logic.