### PR TITLE
Add Cron Job to Disable Events After 24 Hours and Sync Status with Frontend

### DIFF
--- a/backend/cron/eventCron.js
+++ b/backend/cron/eventCron.js
@@ -1,0 +1,16 @@
+const cron = require('node-cron');
+const EventModel = require('../models/eventModel');
+
+
+cron.schedule('* * * * *', async () => {
+    try {
+        const result = await EventModel.completeFinishedEvents();
+        if (result.rowCount > 0) {
+            console.log(`[Cron] ${result.rowCount} evento(s) marcados como Inactive`);
+        }
+    } catch (err) {
+        console.error('[Cron] Error al actualizar eventos:', err.message);
+    }
+});
+
+console.log('[Cron] Tarea de eventos programada (cada minuto)');

--- a/backend/index.js
+++ b/backend/index.js
@@ -23,4 +23,6 @@ app.use('/ticketType', require("./routes/ticketTypeRoute"));
 app.use('/eventTicketType', require("./routes/eventTicketTypeRoute"));
 app.use('/ticket', require('./routes/ticketRoute'));
 
+require('./cron/eventCron');
+
 app.listen(port, () => console.log("Server running on port " + port));

--- a/backend/models/eventModel.js
+++ b/backend/models/eventModel.js
@@ -1,17 +1,29 @@
-const db = require('../database');
+const db = require("../database");
 
 const getActive = (limit, offset) =>
-    db.any("SELECT * FROM events WHERE status = 'Active' ORDER BY id LIMIT $1 OFFSET $2", [limit, offset]);
+  db.any(
+    "SELECT * FROM events WHERE status = 'Active' ORDER BY id LIMIT $1 OFFSET $2",
+    [limit, offset],
+  );
 
 const getAll = (limit, offset) =>
-    db.any('SELECT * FROM events ORDER BY id LIMIT $1 OFFSET $2', [limit, offset]);
+  db.any("SELECT * FROM events ORDER BY id LIMIT $1 OFFSET $2", [
+    limit,
+    offset,
+  ]);
 
-const create = (event) => db.one(`INSERT INTO events (name, date, description, image, category_id, price, status)
+const create = (event) =>
+  db.one(
+    `INSERT INTO events (name, date, description, image, category_id, price, status)
                                   VALUES ($(name), $(date), $(description), $(image), $(category_id),
                                           $(price), $(status))
-                                  RETURNING *`, event);
+                                  RETURNING *`,
+    event,
+  );
 
-const update = (newEvent, id) => db.one(`UPDATE events
+const update = (newEvent, id) =>
+  db.one(
+    `UPDATE events
                                          SET name=$(name),
                                              date=$(date),
                                              description=$(description),
@@ -20,28 +32,47 @@ const update = (newEvent, id) => db.one(`UPDATE events
                                              price=$(price),
                                              status=$(status)
                                          WHERE id = $(id)
-                                         RETURNING *`, {...newEvent, id});
+                                         RETURNING *`,
+    { ...newEvent, id },
+  );
 
-const disable = (id) => db.one(`UPDATE events
+const disable = (id) =>
+  db.one(
+    `UPDATE events
                                 SET status='Inactive'
                                 WHERE id = $(id)
-                                RETURNING *`, {id});
+                                RETURNING *`,
+    { id },
+  );
 
-const getById = (id) => db.oneOrNone('SELECT * FROM events WHERE id = $(id)', {id});
-const interest = (id) => db.none("INSERT INTO interactions (event_id, type) VALUES ($1, 'click')", [id]);
-const getAllInterests = () => db.any('SELECT * FROM interactions');
+const getById = (id) =>
+  db.oneOrNone("SELECT * FROM events WHERE id = $(id)", { id });
+const interest = (id) =>
+  db.none("INSERT INTO interactions (event_id, type) VALUES ($1, 'click')", [
+    id,
+  ]);
+const getAllInterests = () => db.any("SELECT * FROM interactions");
 
 const addFavorite = (userId, eventId) =>
-    db.none('INSERT INTO favorites (user_id, event_id) VALUES ($1, $2)', [userId, eventId]);
+  db.none("INSERT INTO favorites (user_id, event_id) VALUES ($1, $2)", [
+    userId,
+    eventId,
+  ]);
 
 const removeFavorite = (userId, eventId) =>
-    db.none('DELETE FROM favorites WHERE user_id = $1 AND event_id = $2', [userId, eventId]);
+  db.none("DELETE FROM favorites WHERE user_id = $1 AND event_id = $2", [
+    userId,
+    eventId,
+  ]);
 
 const getFavoritesByUser = (userId) =>
-    db.any('SELECT e.* FROM events e JOIN favorites f ON e.id = f.event_id WHERE f.user_id = $1', [userId]);
+  db.any(
+    "SELECT e.* FROM events e JOIN favorites f ON e.id = f.event_id WHERE f.user_id = $1",
+    [userId],
+  );
 
 const getFavoritesReport = () =>
-    db.any(`
+  db.any(`
         SELECT e.id, e.name, COUNT(f.id) AS total_favorites
         FROM events e
                  LEFT JOIN favorites f ON e.id = f.event_id
@@ -49,5 +80,27 @@ const getFavoritesReport = () =>
         ORDER BY total_favorites DESC
     `);
 
-module.exports = {getAll, getActive, create, update, disable, getById, interest, getAllInterests,
-    addFavorite, removeFavorite, getFavoritesByUser, getFavoritesReport};
+const completeFinishedEvents = () =>
+  db.result(`
+        UPDATE events
+        SET status = 'Inactive'
+        WHERE status = 'Active'
+          AND date IS NOT NULL
+          AND date < NOW() - INTERVAL '24 hours'
+    `);
+
+module.exports = {
+  getAll,
+  getActive,
+  create,
+  update,
+  disable,
+  getById,
+  interest,
+  getAllInterests,
+  addFavorite,
+  removeFavorite,
+  getFavoritesByUser,
+  getFavoritesReport,
+    completeFinishedEvents
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
         "jsonwebtoken": "^9.0.3",
+        "node-cron": "^4.2.1",
         "pg-promise": "^12.6.1",
         "qrcode": "^1.5.4",
         "uuid": "^13.0.0"
@@ -1429,6 +1430,15 @@
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/node-gyp-build": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "jsonwebtoken": "^9.0.3",
+    "node-cron": "^4.2.1",
     "pg-promise": "^12.6.1",
     "qrcode": "^1.5.4",
     "uuid": "^13.0.0"

--- a/frontend/src/pages/EventsPage/EventsPage.jsx
+++ b/frontend/src/pages/EventsPage/EventsPage.jsx
@@ -65,6 +65,10 @@ export default function EventsPage() {
 
   useEffect(() => {
     load(page);
+
+    const handleFocus = () => load(page);
+    window.addEventListener("focus", handleFocus);
+    return () => window.removeEventListener("focus", handleFocus);
   }, [page]);
 
   function openModal() {
@@ -122,7 +126,7 @@ export default function EventsPage() {
 
     try {
       const [ett, all] = await Promise.all([
-        getEventTicketTypes(ev.id).catch(() => []), // ← si falla, array vacío
+        getEventTicketTypes(ev.id).catch(() => []),
         getTicketTypes().catch(() => []),
       ]);
 
@@ -213,10 +217,12 @@ export default function EventsPage() {
                   {role === "Admin" && (
                     <span
                       className={
-                        ev.status ? styles.badgeActive : styles.badgeInactive
+                        ev.status === "Active"
+                          ? styles.badgeActive
+                          : styles.badgeInactive
                       }
                     >
-                      {ev.status ? "Activo" : "Inactivo"}
+                      {ev.status === "Active" ? "Activo" : "Inactivo"}
                     </span>
                   )}
                 </div>


### PR DESCRIPTION
This pull request adds automated event lifecycle management through a scheduled cron job. The job runs every minute and checks whether 24 hours have passed since an event’s date. When the condition is met, the event is automatically marked as inactive to prevent further user interactions.

The frontend was updated to reflect these changes in real time. In the user panel, events that have expired are no longer displayed, ensuring a clean and relevant user experience. In the admin panel, expired events remain visible but are clearly marked as inactive, allowing administrators to track historical events and manage them accordingly.

Key changes
Implemented cron job that runs every minute to detect events older than 24 hours.
Automatically sets qualifying events to "inactive" status.
Updated frontend logic to hide inactive events from the user panel.
Updated admin panel to display inactive events with appropriate visual indicators.
Improved event status consistency across the application.