### PR TITLE
Add Business Metrics Module with Event Sales and Global Statistics Endpoints

### DIFF
--- a/backend/controllers/dashboardController.js
+++ b/backend/controllers/dashboardController.js
@@ -1,0 +1,19 @@
+const dashboardService = require('../services/dashboardService');
+
+exports.getGlobalMetrics = async (req, res) => {
+    try {
+        const metrics = await dashboardService.getGlobalMetrics();
+        res.status(200).json(metrics);
+    } catch (err) {
+        res.status(500).json({error: err.message});
+    }
+}
+
+exports.getSalesByEvent = async (req, res) => {
+    try {
+        const report = await dashboardService.getSalesByEvent();
+        res.status(200).json(report);
+    } catch (err) {
+        res.status(500).json({error: err.message});
+    }
+}

--- a/backend/index.js
+++ b/backend/index.js
@@ -22,6 +22,7 @@ app.use('/purchase', require("./routes/purchaseRoute"));
 app.use('/ticketType', require("./routes/ticketTypeRoute"));
 app.use('/eventTicketType', require("./routes/eventTicketTypeRoute"));
 app.use('/ticket', require('./routes/ticketRoute'));
+app.use('/dashboard', require('./routes/dashboardRoute'));
 
 require('./cron/eventCron');
 

--- a/backend/models/dashboardModel.js
+++ b/backend/models/dashboardModel.js
@@ -1,0 +1,28 @@
+const db = require('../database');
+
+const getGlobalMetrics = () => db.one(`
+    SELECT
+        (SELECT COUNT(*) FROM users WHERE status = true)                    AS "totalUsers",
+        (SELECT COUNT(*) FROM events WHERE status != 'Inactive')            AS "totalEvents",
+        (SELECT COALESCE(SUM(total_amount), 0) FROM purchases)              AS "totalRevenue",
+        (SELECT COUNT(*) FROM purchases)                                    AS "totalPurchases",
+        (SELECT COUNT(*) FROM tickets)                                      AS "totalTickets"
+`);
+
+const getSalesByEvent = () => db.any(`
+    SELECT
+        e.id                            AS "eventId",
+        e.name                          AS "eventName",
+        e.date                          AS "eventDate",
+        tt.name                         AS "ticketType",
+        SUM(p.quantity)                 AS "ticketsSold",
+        SUM(p.total_amount)             AS "totalRevenue"
+    FROM events e
+    JOIN event_ticket_types ett ON e.id = ett.event_id
+    JOIN ticket_types tt ON ett.ticket_type_id = tt.id
+    JOIN purchases p ON ett.id = p.event_ticket_type_id
+    GROUP BY e.id, e.name, e.date, tt.name
+    ORDER BY e.id
+`);
+
+module.exports = { getGlobalMetrics, getSalesByEvent };

--- a/backend/routes/dashboardRoute.js
+++ b/backend/routes/dashboardRoute.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const dashboardController = require('../controllers/dashboardController');
+const authentication = require('../middlewares/authMiddleware');
+
+router.get('/metrics', authentication.authenticateToken, authentication.adminAuthorized, dashboardController.getGlobalMetrics);
+router.get('/sales-by-event', authentication.authenticateToken, authentication.adminAuthorized, dashboardController.getSalesByEvent);
+
+module.exports = router;

--- a/backend/services/dashboardService.js
+++ b/backend/services/dashboardService.js
@@ -1,0 +1,9 @@
+const DashboardModel = require('../models/dashboardModel');
+
+exports.getGlobalMetrics = () => {
+    return DashboardModel.getGlobalMetrics();
+}
+
+exports.getSalesByEvent = () => {
+    return DashboardModel.getSalesByEvent();
+}


### PR DESCRIPTION
This pull request introduces a new backend module dedicated to business metrics. The module provides endpoints that deliver key operational insights, including event-specific sales metrics as well as aggregated global statistics.

The new endpoints allow consumers (such as the admin panel) to retrieve detailed event sales information and overall platform metrics such as total users, total events, total revenue, total sales, and total tickets sold. This module lays the foundation for reporting, dashboards, and future analytics features.

Key changes
Added new backend module for business metrics.
Implemented endpoint for retrieving sales metrics per event.
Implemented global metrics endpoint: total users, total events, total revenue, total sales, and total tickets.
Integrated services to aggregate and compute metrics efficiently.
Structured responses to support analytics and admin dashboards.