### PR TITLE
fix: Disable Ticket-Management Options for Inactive Events in Admin Pane

### DIFF
--- a/backend/services/eventService.js
+++ b/backend/services/eventService.js
@@ -18,8 +18,14 @@ exports.viewAllEvents = async (page) => {
     return EventModel.getAll(limit, offset);
 }
 
-exports.updateEvent = (newEvent,id) => {
-    return EventModel.update(newEvent,id);
+exports.updateEvent = async (newEvent, id) => {
+    const current = await EventModel.getById(id);
+    const eventToUpdate = {
+        ...current,
+        ...newEvent,
+        status: newEvent.status || current.status 
+    };
+    return EventModel.update(eventToUpdate, id);
 }
 
 exports.disableEvent = (id) => {

--- a/frontend/src/pages/EventsPage/EventsPage.jsx
+++ b/frontend/src/pages/EventsPage/EventsPage.jsx
@@ -229,6 +229,7 @@ export default function EventsPage() {
                 {role === "Admin" && (
                   <button
                     className={styles.btnTicket}
+                    disabled={ev.status !== "Active"}
                     onClick={(e) => {
                       e.stopPropagation();
                       openTicketModal(ev);

--- a/frontend/src/pages/EventsPage/EventsPage.module.css
+++ b/frontend/src/pages/EventsPage/EventsPage.module.css
@@ -273,3 +273,8 @@
   padding-top: 0.25rem;
   border-top: 1.5px solid var(--border);
 }
+
+.btnTicket:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}


### PR DESCRIPTION
This pull request fixes a logic issue in the admin panel where ticket-management actions were still available for events marked as inactive. The UI now correctly disables these options, preventing administrators from creating or modifying ticket types for events that are no longer active.

This update ensures consistency with backend rules and improves overall system integrity by avoiding unintended modifications to expired or disabled events.

Key changes
Fixed logic to disable ticket-management controls when an event is inactive.
Updated admin panel UI to visually reflect disabled state.
Ensured consistency with backend event-status validation.